### PR TITLE
Fix NuGet trusted publishing: remove manual OIDC token fetch

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -49,7 +49,14 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: nuget-packages
+    - name: NuGet login (Trusted Publishing)
+      uses: NuGet/login@v1
+      id: login
+      with:
+        user: ${{ secrets.NUGET_USER }}
     - name: Push to NuGet
-      run: |
-        dotnet nuget push *.nupkg --source https://api.nuget.org/v3/index.json --skip-duplicate
-        dotnet nuget push *.snupkg --source https://api.nuget.org/v3/index.json --skip-duplicate
+      run: >
+        dotnet nuget push "*.nupkg"
+        --api-key "${{ steps.login.outputs.NUGET_API_KEY }}"
+        --source https://api.nuget.org/v3/index.json
+        --skip-duplicate

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -49,17 +49,7 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: nuget-packages
-    - name: Get NuGet OIDC token
-      id: oidc
-      uses: actions/github-script@v7
-      with:
-        script: |
-          const token = await core.getIDToken('api.nuget.org');
-          core.setSecret(token);
-          core.setOutput('token', token);
     - name: Push to NuGet
-      env:
-        NUGET_TOKEN: ${{ steps.oidc.outputs.token }}
       run: |
-        dotnet nuget push *.nupkg --source https://api.nuget.org/v3/index.json --api-key "$NUGET_TOKEN" --skip-duplicate
-        dotnet nuget push *.snupkg --source https://api.nuget.org/v3/index.json --api-key "$NUGET_TOKEN" --skip-duplicate
+        dotnet nuget push *.nupkg --source https://api.nuget.org/v3/index.json --skip-duplicate
+        dotnet nuget push *.snupkg --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
## Summary

- Removes the `actions/github-script` OIDC token fetch step that was added in #39
- Removes `--api-key "$NUGET_TOKEN"` from the push commands

## Why

Passing the raw GitHub OIDC JWT directly as `--api-key` doesn't work — NuGet returns 403. The NuGet CLI (6.8+, bundled with .NET 8 SDK) performs the OIDC token exchange **internally** when `id-token: write` is granted and **no `--api-key` is provided**. The `ACTIONS_ID_TOKEN_REQUEST_URL` / `ACTIONS_ID_TOKEN_REQUEST_TOKEN` env vars are set automatically by the runner and the NuGet CLI uses them to fetch and exchange the token transparently.

## Test plan

- [ ] Merge to `main` and confirm the `publish` job completes without 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)